### PR TITLE
[2022.08.09] 강원희 뉴스 클러스터링

### DIFF
--- a/src/뉴스클러스터링.js
+++ b/src/뉴스클러스터링.js
@@ -1,0 +1,30 @@
+function solution(str1, str2) {
+  str1 = str1.toUpperCase();
+  str2 = str2.toUpperCase();
+
+  const str1Arr = [];
+  const str2Arr = [];
+
+  [...str1].forEach((_, index) =>
+    str1[index] >= "A" &&
+    str1[index] <= "Z" &&
+    str1[index + 1] >= "A" &&
+    str1[index + 1] <= "Z"
+      ? str1Arr.push(str1[index] + str1[index + 1])
+      : null
+  );
+
+  [...str2].forEach((_, index) =>
+    str2[index] >= "A" &&
+    str2[index] <= "Z" &&
+    str2[index + 1] >= "A" &&
+    str2[index + 1] <= "Z"
+      ? str2Arr.push(str2[index] + str2[index + 1])
+      : null
+  );
+
+  const intersection = str1Arr.filter((elem) => str2Arr.includes(elem));
+  const sumArr = [...new Set([...str1Arr, ...str2Arr])];
+
+  return Math.floor((intersection.length / sumArr.length) * 65536);
+}


### PR DESCRIPTION
## 뉴스 클러스터링
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/93723399/183550034-462eb393-6ed3-434a-a3b5-f35d70669657.png">

### 💡 문제를 해결한 방식
1. 모두 대문자로 바꾸어주고
2. 배열에 2글자씩(대문자 알파벳일때만) 추가해주고
3. 교집합, 합집합을 구하고
4. 소수점 아래 제거(교집합의 길이 / 합집합의 길이 * 65536)

### ❓ 관련해 궁금한 점이나 아쉬운 점
- 현재 빈칸이나 특수문자가 들어올 경우의 테스트케이스들에 문제가 있어 수정이 필요해보입니다
- 시간이 다되어 제출합니다. 조언해주시면 고민해보고 반영하겠습니다
- 감사합니다!

### 🚴‍♂️ 시간 복잡도
* N:
* 시간 복잡도: filter와 includes때문에 O(n^2)라고 생각하는데 어떻게 생각하시나요?
