### PR TITLE
[2022.08.09] 김준형 뉴스 클러스터링

### DIFF
--- a/src/뉴스 클러스터링.js
+++ b/src/뉴스 클러스터링.js
@@ -1,0 +1,46 @@
+function solution(str1, str2) {
+  const [lowStr1, lowStr2] = [str1.toLowerCase(), str2.toLowerCase()];
+  const alpRegex = /^[a-z|A-Z]+$/;
+  const [subArr1, subArr2] = [[], []];
+
+  for (let i = 0; i < lowStr1.length - 1; i++) {
+    const candidate = lowStr1.substring(i, i + 2);
+
+    if (!alpRegex.test(candidate)) continue;
+
+    subArr1.push(candidate);
+  }
+
+  for (let i = 0; i < lowStr2.length - 1; i++) {
+    const candidate = lowStr2.substring(i, i + 2);
+
+    if (!alpRegex.test(candidate)) continue;
+
+    subArr2.push(candidate);
+  }
+
+  const [set1, set2] = [new Set(subArr1), new Set(subArr2)];
+  const union = new Set([...set1, ...set2]);
+  const intersection = new Set([...set1].filter((x) => set2.has(x)));
+  let [intersectionSize, unionSize] = [0, 0];
+
+  union.forEach(
+    (element) =>
+      (unionSize += Math.max(
+        subArr1.filter((v) => v === element).length,
+        subArr2.filter((v) => v === element).length
+      ))
+  );
+
+  intersection.forEach(
+    (element) =>
+      (intersectionSize += Math.min(
+        subArr1.filter((v) => v === element).length,
+        subArr2.filter((v) => v === element).length
+      ))
+  );
+
+  return intersectionSize === unionSize
+    ? 65536
+    : parseInt((intersectionSize / unionSize) * 65536);
+}


### PR DESCRIPTION
## 뉴스 클러스터링

![image](https://user-images.githubusercontent.com/41819129/183550799-5baab028-f8f5-43f2-aedb-cc4629c64b7a.png)

### 💡 문제를 해결한 방식
- 소문자로 문자열 변경
- 자르고, 부분문자열이 알파벳으로만 이루어져있을 때 배열에 넣는다.
- Set으로 중복제거후 교집합, 합집합을 구한다.
- 다중집합의 경우를 고려하여 교집합, 합집합 크기를 구한다.

### ❓ 관련해 궁금한 점이나 아쉬운 점

### 🚴‍♂️ 시간 복잡도
* N: 주어진 문자열 중 더 큰 길이
* 시간 복잡도: O(N^2)

오늘 침수되어 늦게 풀기 시작해 코드를 정리하지 못했네요...

예외 케이스나 피드백 신랄하게 부탁드립니다!  
오늘도 감사합니다.
