### PR TITLE
[2022.08.09] 김다은 뉴스 클러스터링

### DIFF
--- a/src/뉴스클러스터링.js
+++ b/src/뉴스클러스터링.js
@@ -1,0 +1,37 @@
+function solution(str1, str2) {
+  const intersection = [];
+  const union = [];
+
+  const multiSets = (str, arr = []) => {
+    for (let i = 0; i < str.length - 1; i++) {
+      const sliceStr = str.slice(i, i + 2).toLowerCase();
+
+      if (/^[a-zA-Z]+$/g.test(sliceStr)) {
+        arr.push(sliceStr);
+      }
+    }
+
+    return arr;
+  }
+
+  const multiSet1 = multiSets(str1);
+  const multiSet2 = multiSets(str2);
+
+  for (let i = 0; i < multiSet2.length; i++) {
+    if (multiSet1.indexOf(multiSet2[i]) >= 0) {
+      intersection.push(multiSet1.splice(multiSet1.indexOf(multiSet2[i]), 1));
+    }
+
+    union.push(multiSet2[i]);
+  }
+
+  for (let i = 0; i < multiSet1.length; i++) {
+    union.push(multiSet1[i]);
+  }
+
+  if (union.length === 0) {
+    return 65536;
+  }
+
+  return Math.floor(intersection.length / union.length * 65536);
+}


### PR DESCRIPTION
## 문제명
뉴스 클러스터링

### 💡 문제를 해결한 방식
테스트 모두 통과했습니다.

1. 들어온 str1, str2 문자열을 두 글자 씩 끊어 다중집합으로 만들어주었습니다.
2. 첫번째 다중집합 배열과 두번째 다중집합 배열에 같은 요소가 있다면 교집합 배열에 넣어주었습니다.
3. 첫번째 다중집합 배열과 두번째 다중집합 배열을 모두 합쳐 합집합 배열에 넣어주었습니다.
4. 교집합 배열의 길이 / 합집합 배열의 길이 * 65536 를 Math.floor()를 사용해 소수점을 버린 값을 리턴해주었습니다.

리뷰해주셔서 감사합니다.
